### PR TITLE
Consume extend blocks

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -56,8 +56,11 @@ module.exports = function parser(identifier, string) {
       case 'message':
         parseMessage(proto)
         break
-       case 'enum':
+      case 'enum':
         parseEnum(proto)
+        break
+      case 'extend':
+        parseExtend(proto)
         break
 
       default:
@@ -194,6 +197,14 @@ module.exports = function parser(identifier, string) {
       var number = expect(Token.Type.NUMBER)
       expect(Token.Type.TERMINATOR)
       enumeration.addValue(name, Number(number.content))
+    })
+  }
+
+  // Parses extend: extend google.protobuf.MessageOptions {optional string type = 50001;}
+  function parseExtend(parent) {
+    var name = expect(Token.Type.WORD).content
+    parseBlock(function (token) {
+      // TODO : parse and add to descriptor
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbnj",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "keywords": ["protocol", "buffer", "proto", "protobuf", "parser", "codegen"],
   "description": "JavaScript protocol buffer schema parser and template based code generator",
   "homepage": "https://github.com/dpup/pbnj",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "mkdirp": "0.3.5",
-    "nodeunit": "0.8.0",
+    "nodeunit": "0.8.2",
     "kew": "0.4.0",
     "soynode": "0.3.5"
   }

--- a/tests/parsing_test.js
+++ b/tests/parsing_test.js
@@ -20,7 +20,7 @@ exports.testKitchenSinkParsing = function (test) {
   test.equal(proto.getPackage(), 'some_package')
 
   // Test imports.
-  test.equal(proto.getImportNames().length, 1)
+  test.equal(proto.getImportNames().length, 2)
   test.equal(proto.getImportNames()[0], path.join(process.cwd(), 'tests/protos/options.proto'))
 
   // Test proto level options.
@@ -98,6 +98,13 @@ exports.testBadProto_unexpectedChars = function (test) {
       'Unexpected characters in "test.proto" at line: 1, column: 42, char: $',
       'Bad characters',
       test)
+}
+
+
+exports.testExtendConsumed = function (test) {
+  var proto = parseFile('options.proto')
+  // TODO : Verify descriptor is extended
+  test.done()
 }
 
 

--- a/tests/protos/kitchen-sink.proto
+++ b/tests/protos/kitchen-sink.proto
@@ -7,6 +7,7 @@
 package some_package;
 
 import "tests/protos/options.proto";
+import "google/protobuf/descriptor.proto";
 
 option (file_level_option) = "string value";
 option (another_option) = "Just \"testing\" that strings parse.";
@@ -37,6 +38,11 @@ message AnotherMessage {
       NO = 2;
     }
   }
+}
+
+
+extend google.protobuf.MessageOptions {
+  optional string message_type = 50004;
 }
 
 


### PR DESCRIPTION
Consumes extend blocks so they don't throw errors, left a TODO to actually add them to the descriptor. 