### PR TITLE
clean up how proto imports are handled, and include descriptor.proto by default for portability

### DIFF
--- a/include/google/protobuf/descriptor.proto
+++ b/include/google/protobuf/descriptor.proto
@@ -1,0 +1,620 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// http://code.google.com/p/protobuf/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// The messages in this file describe the definitions found in .proto files.
+// A valid .proto file can be translated directly to a FileDescriptorProto
+// without any other information (e.g. without reading its imports).
+
+
+
+package google.protobuf;
+option java_package = "com.google.protobuf";
+option java_outer_classname = "DescriptorProtos";
+
+// descriptor.proto must be optimized for speed because reflection-based
+// algorithms don't work during bootstrapping.
+option optimize_for = SPEED;
+
+// The protocol compiler can output a FileDescriptorSet containing the .proto
+// files it parses.
+message FileDescriptorSet {
+  repeated FileDescriptorProto file = 1;
+}
+
+// Describes a complete .proto file.
+message FileDescriptorProto {
+  optional string name = 1;       // file name, relative to root of source tree
+  optional string package = 2;    // e.g. "foo", "foo.bar", etc.
+
+  // Names of files imported by this file.
+  repeated string dependency = 3;
+  // Indexes of the public imported files in the dependency list above.
+  repeated int32 public_dependency = 10;
+  // Indexes of the weak imported files in the dependency list.
+  // For Google-internal migration only. Do not use.
+  repeated int32 weak_dependency = 11;
+
+  // All top-level definitions in this file.
+  repeated DescriptorProto message_type = 4;
+  repeated EnumDescriptorProto enum_type = 5;
+  repeated ServiceDescriptorProto service = 6;
+  repeated FieldDescriptorProto extension = 7;
+
+  optional FileOptions options = 8;
+
+  // This field contains optional information about the original source code.
+  // You may safely remove this entire field whithout harming runtime
+  // functionality of the descriptors -- the information is needed only by
+  // development tools.
+  optional SourceCodeInfo source_code_info = 9;
+}
+
+// Describes a message type.
+message DescriptorProto {
+  optional string name = 1;
+
+  repeated FieldDescriptorProto field = 2;
+  repeated FieldDescriptorProto extension = 6;
+
+  repeated DescriptorProto nested_type = 3;
+  repeated EnumDescriptorProto enum_type = 4;
+
+  message ExtensionRange {
+    optional int32 start = 1;
+    optional int32 end = 2;
+  }
+  repeated ExtensionRange extension_range = 5;
+
+  optional MessageOptions options = 7;
+}
+
+// Describes a field within a message.
+message FieldDescriptorProto {
+  enum Type {
+    // 0 is reserved for errors.
+    // Order is weird for historical reasons.
+    TYPE_DOUBLE         = 1;
+    TYPE_FLOAT          = 2;
+    // Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+    // negative values are likely.
+    TYPE_INT64          = 3;
+    TYPE_UINT64         = 4;
+    // Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+    // negative values are likely.
+    TYPE_INT32          = 5;
+    TYPE_FIXED64        = 6;
+    TYPE_FIXED32        = 7;
+    TYPE_BOOL           = 8;
+    TYPE_STRING         = 9;
+    TYPE_GROUP          = 10;  // Tag-delimited aggregate.
+    TYPE_MESSAGE        = 11;  // Length-delimited aggregate.
+
+    // New in version 2.
+    TYPE_BYTES          = 12;
+    TYPE_UINT32         = 13;
+    TYPE_ENUM           = 14;
+    TYPE_SFIXED32       = 15;
+    TYPE_SFIXED64       = 16;
+    TYPE_SINT32         = 17;  // Uses ZigZag encoding.
+    TYPE_SINT64         = 18;  // Uses ZigZag encoding.
+  };
+
+  enum Label {
+    // 0 is reserved for errors
+    LABEL_OPTIONAL      = 1;
+    LABEL_REQUIRED      = 2;
+    LABEL_REPEATED      = 3;
+    // TODO(sanjay): Should we add LABEL_MAP?
+  };
+
+  optional string name = 1;
+  optional int32 number = 3;
+  optional Label label = 4;
+
+  // If type_name is set, this need not be set.  If both this and type_name
+  // are set, this must be either TYPE_ENUM or TYPE_MESSAGE.
+  optional Type type = 5;
+
+  // For message and enum types, this is the name of the type.  If the name
+  // starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+  // rules are used to find the type (i.e. first the nested types within this
+  // message are searched, then within the parent, on up to the root
+  // namespace).
+  optional string type_name = 6;
+
+  // For extensions, this is the name of the type being extended.  It is
+  // resolved in the same manner as type_name.
+  optional string extendee = 2;
+
+  // For numeric types, contains the original text representation of the value.
+  // For booleans, "true" or "false".
+  // For strings, contains the default text contents (not escaped in any way).
+  // For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
+  // TODO(kenton):  Base-64 encode?
+  optional string default_value = 7;
+
+  optional FieldOptions options = 8;
+}
+
+// Describes an enum type.
+message EnumDescriptorProto {
+  optional string name = 1;
+
+  repeated EnumValueDescriptorProto value = 2;
+
+  optional EnumOptions options = 3;
+}
+
+// Describes a value within an enum.
+message EnumValueDescriptorProto {
+  optional string name = 1;
+  optional int32 number = 2;
+
+  optional EnumValueOptions options = 3;
+}
+
+// Describes a service.
+message ServiceDescriptorProto {
+  optional string name = 1;
+  repeated MethodDescriptorProto method = 2;
+
+  optional ServiceOptions options = 3;
+}
+
+// Describes a method of a service.
+message MethodDescriptorProto {
+  optional string name = 1;
+
+  // Input and output type names.  These are resolved in the same way as
+  // FieldDescriptorProto.type_name, but must refer to a message type.
+  optional string input_type = 2;
+  optional string output_type = 3;
+
+  optional MethodOptions options = 4;
+}
+
+
+// ===================================================================
+// Options
+
+// Each of the definitions above may have "options" attached.  These are
+// just annotations which may cause code to be generated slightly differently
+// or may contain hints for code that manipulates protocol messages.
+//
+// Clients may define custom options as extensions of the *Options messages.
+// These extensions may not yet be known at parsing time, so the parser cannot
+// store the values in them.  Instead it stores them in a field in the *Options
+// message called uninterpreted_option. This field must have the same name
+// across all *Options messages. We then use this field to populate the
+// extensions when we build a descriptor, at which point all protos have been
+// parsed and so all extensions are known.
+//
+// Extension numbers for custom options may be chosen as follows:
+// * For options which will only be used within a single application or
+//   organization, or for experimental options, use field numbers 50000
+//   through 99999.  It is up to you to ensure that you do not use the
+//   same number for multiple options.
+// * For options which will be published and used publicly by multiple
+//   independent entities, e-mail protobuf-global-extension-registry@google.com
+//   to reserve extension numbers. Simply provide your project name (e.g.
+//   Object-C plugin) and your porject website (if available) -- there's no need
+//   to explain how you intend to use them. Usually you only need one extension
+//   number. You can declare multiple options with only one extension number by
+//   putting them in a sub-message. See the Custom Options section of the docs
+//   for examples:
+//   http://code.google.com/apis/protocolbuffers/docs/proto.html#options
+//   If this turns out to be popular, a web service will be set up
+//   to automatically assign option numbers.
+
+
+message FileOptions {
+
+  // Sets the Java package where classes generated from this .proto will be
+  // placed.  By default, the proto package is used, but this is often
+  // inappropriate because proto packages do not normally start with backwards
+  // domain names.
+  optional string java_package = 1;
+
+
+  // If set, all the classes from the .proto file are wrapped in a single
+  // outer class with the given name.  This applies to both Proto1
+  // (equivalent to the old "--one_java_file" option) and Proto2 (where
+  // a .proto always translates to a single class, but you may want to
+  // explicitly choose the class name).
+  optional string java_outer_classname = 8;
+
+  // If set true, then the Java code generator will generate a separate .java
+  // file for each top-level message, enum, and service defined in the .proto
+  // file.  Thus, these types will *not* be nested inside the outer class
+  // named by java_outer_classname.  However, the outer class will still be
+  // generated to contain the file's getDescriptor() method as well as any
+  // top-level extensions defined in the file.
+  optional bool java_multiple_files = 10 [default=false];
+
+  // If set true, then the Java code generator will generate equals() and
+  // hashCode() methods for all messages defined in the .proto file. This is
+  // purely a speed optimization, as the AbstractMessage base class includes
+  // reflection-based implementations of these methods.
+  optional bool java_generate_equals_and_hash = 20 [default=false];
+
+  // Generated classes can be optimized for speed or code size.
+  enum OptimizeMode {
+    SPEED = 1;        // Generate complete code for parsing, serialization,
+                      // etc.
+    CODE_SIZE = 2;    // Use ReflectionOps to implement these methods.
+    LITE_RUNTIME = 3; // Generate code using MessageLite and the lite runtime.
+  }
+  optional OptimizeMode optimize_for = 9 [default=SPEED];
+
+  // Sets the Go package where structs generated from this .proto will be
+  // placed.  There is no default.
+  optional string go_package = 11;
+
+
+
+  // Should generic services be generated in each language?  "Generic" services
+  // are not specific to any particular RPC system.  They are generated by the
+  // main code generators in each language (without additional plugins).
+  // Generic services were the only kind of service generation supported by
+  // early versions of proto2.
+  //
+  // Generic services are now considered deprecated in favor of using plugins
+  // that generate code specific to your particular RPC system.  Therefore,
+  // these default to false.  Old code which depends on generic services should
+  // explicitly set them to true.
+  optional bool cc_generic_services = 16 [default=false];
+  optional bool java_generic_services = 17 [default=false];
+  optional bool py_generic_services = 18 [default=false];
+
+  // The parser stores options it doesn't recognize here. See above.
+  repeated UninterpretedOption uninterpreted_option = 999;
+
+  // Clients can define custom options in extensions of this message. See above.
+  extensions 1000 to max;
+}
+
+message MessageOptions {
+  // Set true to use the old proto1 MessageSet wire format for extensions.
+  // This is provided for backwards-compatibility with the MessageSet wire
+  // format.  You should not use this for any other reason:  It's less
+  // efficient, has fewer features, and is more complicated.
+  //
+  // The message must be defined exactly as follows:
+  //   message Foo {
+  //     option message_set_wire_format = true;
+  //     extensions 4 to max;
+  //   }
+  // Note that the message cannot have any defined fields; MessageSets only
+  // have extensions.
+  //
+  // All extensions of your type must be singular messages; e.g. they cannot
+  // be int32s, enums, or repeated messages.
+  //
+  // Because this is an option, the above two restrictions are not enforced by
+  // the protocol compiler.
+  optional bool message_set_wire_format = 1 [default=false];
+
+  // Disables the generation of the standard "descriptor()" accessor, which can
+  // conflict with a field of the same name.  This is meant to make migration
+  // from proto1 easier; new code should avoid fields named "descriptor".
+  optional bool no_standard_descriptor_accessor = 2 [default=false];
+
+  // The parser stores options it doesn't recognize here. See above.
+  repeated UninterpretedOption uninterpreted_option = 999;
+
+  // Clients can define custom options in extensions of this message. See above.
+  extensions 1000 to max;
+}
+
+message FieldOptions {
+  // The ctype option instructs the C++ code generator to use a different
+  // representation of the field than it normally would.  See the specific
+  // options below.  This option is not yet implemented in the open source
+  // release -- sorry, we'll try to include it in a future version!
+  optional CType ctype = 1 [default = STRING];
+  enum CType {
+    // Default mode.
+    STRING = 0;
+
+    CORD = 1;
+
+    STRING_PIECE = 2;
+  }
+  // The packed option can be enabled for repeated primitive fields to enable
+  // a more efficient representation on the wire. Rather than repeatedly
+  // writing the tag and type for each element, the entire array is encoded as
+  // a single length-delimited blob.
+  optional bool packed = 2;
+
+
+
+  // Should this field be parsed lazily?  Lazy applies only to message-type
+  // fields.  It means that when the outer message is initially parsed, the
+  // inner message's contents will not be parsed but instead stored in encoded
+  // form.  The inner message will actually be parsed when it is first accessed.
+  //
+  // This is only a hint.  Implementations are free to choose whether to use
+  // eager or lazy parsing regardless of the value of this option.  However,
+  // setting this option true suggests that the protocol author believes that
+  // using lazy parsing on this field is worth the additional bookkeeping
+  // overhead typically needed to implement it.
+  //
+  // This option does not affect the public interface of any generated code;
+  // all method signatures remain the same.  Furthermore, thread-safety of the
+  // interface is not affected by this option; const methods remain safe to
+  // call from multiple threads concurrently, while non-const methods continue
+  // to require exclusive access.
+  //
+  //
+  // Note that implementations may choose not to check required fields within
+  // a lazy sub-message.  That is, calling IsInitialized() on the outher message
+  // may return true even if the inner message has missing required fields.
+  // This is necessary because otherwise the inner message would have to be
+  // parsed in order to perform the check, defeating the purpose of lazy
+  // parsing.  An implementation which chooses not to check required fields
+  // must be consistent about it.  That is, for any particular sub-message, the
+  // implementation must either *always* check its required fields, or *never*
+  // check its required fields, regardless of whether or not the message has
+  // been parsed.
+  optional bool lazy = 5 [default=false];
+
+  // Is this field deprecated?
+  // Depending on the target platform, this can emit Deprecated annotations
+  // for accessors, or it will be completely ignored; in the very least, this
+  // is a formalization for deprecating fields.
+  optional bool deprecated = 3 [default=false];
+
+  // EXPERIMENTAL.  DO NOT USE.
+  // For "map" fields, the name of the field in the enclosed type that
+  // is the key for this map.  For example, suppose we have:
+  //   message Item {
+  //     required string name = 1;
+  //     required string value = 2;
+  //   }
+  //   message Config {
+  //     repeated Item items = 1 [experimental_map_key="name"];
+  //   }
+  // In this situation, the map key for Item will be set to "name".
+  // TODO: Fully-implement this, then remove the "experimental_" prefix.
+  optional string experimental_map_key = 9;
+
+  // For Google-internal migration only. Do not use.
+  optional bool weak = 10 [default=false];
+
+  // The parser stores options it doesn't recognize here. See above.
+  repeated UninterpretedOption uninterpreted_option = 999;
+
+  // Clients can define custom options in extensions of this message. See above.
+  extensions 1000 to max;
+}
+
+message EnumOptions {
+
+  // Set this option to false to disallow mapping different tag names to a same
+  // value.
+  optional bool allow_alias = 2 [default=true];
+
+  // The parser stores options it doesn't recognize here. See above.
+  repeated UninterpretedOption uninterpreted_option = 999;
+
+  // Clients can define custom options in extensions of this message. See above.
+  extensions 1000 to max;
+}
+
+message EnumValueOptions {
+  // The parser stores options it doesn't recognize here. See above.
+  repeated UninterpretedOption uninterpreted_option = 999;
+
+  // Clients can define custom options in extensions of this message. See above.
+  extensions 1000 to max;
+}
+
+message ServiceOptions {
+
+  // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
+  //   framework.  We apologize for hoarding these numbers to ourselves, but
+  //   we were already using them long before we decided to release Protocol
+  //   Buffers.
+
+  // The parser stores options it doesn't recognize here. See above.
+  repeated UninterpretedOption uninterpreted_option = 999;
+
+  // Clients can define custom options in extensions of this message. See above.
+  extensions 1000 to max;
+}
+
+message MethodOptions {
+
+  // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
+  //   framework.  We apologize for hoarding these numbers to ourselves, but
+  //   we were already using them long before we decided to release Protocol
+  //   Buffers.
+
+  // The parser stores options it doesn't recognize here. See above.
+  repeated UninterpretedOption uninterpreted_option = 999;
+
+  // Clients can define custom options in extensions of this message. See above.
+  extensions 1000 to max;
+}
+
+
+// A message representing a option the parser does not recognize. This only
+// appears in options protos created by the compiler::Parser class.
+// DescriptorPool resolves these when building Descriptor objects. Therefore,
+// options protos in descriptor objects (e.g. returned by Descriptor::options(),
+// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+// in them.
+message UninterpretedOption {
+  // The name of the uninterpreted option.  Each string represents a segment in
+  // a dot-separated name.  is_extension is true iff a segment represents an
+  // extension (denoted with parentheses in options specs in .proto files).
+  // E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
+  // "foo.(bar.baz).qux".
+  message NamePart {
+    required string name_part = 1;
+    required bool is_extension = 2;
+  }
+  repeated NamePart name = 2;
+
+  // The value of the uninterpreted option, in whatever type the tokenizer
+  // identified it as during parsing. Exactly one of these should be set.
+  optional string identifier_value = 3;
+  optional uint64 positive_int_value = 4;
+  optional int64 negative_int_value = 5;
+  optional double double_value = 6;
+  optional bytes string_value = 7;
+  optional string aggregate_value = 8;
+}
+
+// ===================================================================
+// Optional source code info
+
+// Encapsulates information about the original source file from which a
+// FileDescriptorProto was generated.
+message SourceCodeInfo {
+  // A Location identifies a piece of source code in a .proto file which
+  // corresponds to a particular definition.  This information is intended
+  // to be useful to IDEs, code indexers, documentation generators, and similar
+  // tools.
+  //
+  // For example, say we have a file like:
+  //   message Foo {
+  //     optional string foo = 1;
+  //   }
+  // Let's look at just the field definition:
+  //   optional string foo = 1;
+  //   ^       ^^     ^^  ^  ^^^
+  //   a       bc     de  f  ghi
+  // We have the following locations:
+  //   span   path               represents
+  //   [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+  //   [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+  //   [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+  //   [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+  //   [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+  //
+  // Notes:
+  // - A location may refer to a repeated field itself (i.e. not to any
+  //   particular index within it).  This is used whenever a set of elements are
+  //   logically enclosed in a single code segment.  For example, an entire
+  //   extend block (possibly containing multiple extension definitions) will
+  //   have an outer location whose path refers to the "extensions" repeated
+  //   field without an index.
+  // - Multiple locations may have the same path.  This happens when a single
+  //   logical declaration is spread out across multiple places.  The most
+  //   obvious example is the "extend" block again -- there may be multiple
+  //   extend blocks in the same scope, each of which will have the same path.
+  // - A location's span is not always a subset of its parent's span.  For
+  //   example, the "extendee" of an extension declaration appears at the
+  //   beginning of the "extend" block and is shared by all extensions within
+  //   the block.
+  // - Just because a location's span is a subset of some other location's span
+  //   does not mean that it is a descendent.  For example, a "group" defines
+  //   both a type and a field in a single declaration.  Thus, the locations
+  //   corresponding to the type and field and their components will overlap.
+  // - Code which tries to interpret locations should probably be designed to
+  //   ignore those that it doesn't understand, as more types of locations could
+  //   be recorded in the future.
+  repeated Location location = 1;
+  message Location {
+    // Identifies which part of the FileDescriptorProto was defined at this
+    // location.
+    //
+    // Each element is a field number or an index.  They form a path from
+    // the root FileDescriptorProto to the place where the definition.  For
+    // example, this path:
+    //   [ 4, 3, 2, 7, 1 ]
+    // refers to:
+    //   file.message_type(3)  // 4, 3
+    //       .field(7)         // 2, 7
+    //       .name()           // 1
+    // This is because FileDescriptorProto.message_type has field number 4:
+    //   repeated DescriptorProto message_type = 4;
+    // and DescriptorProto.field has field number 2:
+    //   repeated FieldDescriptorProto field = 2;
+    // and FieldDescriptorProto.name has field number 1:
+    //   optional string name = 1;
+    //
+    // Thus, the above path gives the location of a field name.  If we removed
+    // the last element:
+    //   [ 4, 3, 2, 7 ]
+    // this path refers to the whole field declaration (from the beginning
+    // of the label to the terminating semicolon).
+    repeated int32 path = 1 [packed=true];
+
+    // Always has exactly three or four elements: start line, start column,
+    // end line (optional, otherwise assumed same as start line), end column.
+    // These are packed into a single field for efficiency.  Note that line
+    // and column numbers are zero-based -- typically you will want to add
+    // 1 to each before displaying to a user.
+    repeated int32 span = 2 [packed=true];
+
+    // If this SourceCodeInfo represents a complete declaration, these are any
+    // comments appearing before and after the declaration which appear to be
+    // attached to the declaration.
+    //
+    // A series of line comments appearing on consecutive lines, with no other
+    // tokens appearing on those lines, will be treated as a single comment.
+    //
+    // Only the comment content is provided; comment markers (e.g. //) are
+    // stripped out.  For block comments, leading whitespace and an asterisk
+    // will be stripped from the beginning of each line other than the first.
+    // Newlines are included in the output.
+    //
+    // Examples:
+    //
+    //   optional int32 foo = 1;  // Comment attached to foo.
+    //   // Comment attached to bar.
+    //   optional int32 bar = 2;
+    //
+    //   optional string baz = 3;
+    //   // Comment attached to baz.
+    //   // Another line attached to baz.
+    //
+    //   // Comment attached to qux.
+    //   //
+    //   // Another line attached to qux.
+    //   optional double qux = 4;
+    //
+    //   optional string corge = 5;
+    //   /* Block comment attached
+    //    * to corge.  Leading asterisks
+    //    * will be removed. */
+    //   /* Block comment attached to
+    //    * grault. */
+    //   optional int32 grault = 6;
+    optional string leading_comments = 3;
+    optional string trailing_comments = 4;
+  }
+}

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -15,16 +15,21 @@ var parser = require('./parser')
 
 
 /**
- * @param {string=} opt_basePath Defaults to current working directory.
+ * @param {string=} opt_basePath The base path, for a default configuration
+ *     of protoc_path and out_path.
  * @constructor
  */
 function Project(opt_basePath) {
+  var basePath = opt_basePath || process.cwd()
+
+  /** @private {string} */
+  this._basePath = basePath
 
   /**
-   * Look for protos starting at the specified path, defaults to cwd.
-   * @private {string}
+   * Look for protos starting at the specified path. Defaults to cwd and default includes.
+   * @private {Array.<string>}
    */
-  this._basePath = opt_basePath || process.cwd()
+  this._protocPaths = [basePath, path.resolve(__dirname, '../include')]
 
   /**
    * Follow imports for parsing and adding protos
@@ -36,13 +41,13 @@ function Project(opt_basePath) {
    * Where files are output to.
    * @private {string}
    */
-  this._outDir = path.join(this._basePath, 'genfiles')
+  this._outDir = path.join(basePath, 'genfiles')
 
   /**
    * The template directory, relative to the base path.
    * @private {string}
    */
-  this._templateDir = ''
+  this._templateDir = basePath
 
   /**
    * Suffix for generated files.
@@ -51,7 +56,7 @@ function Project(opt_basePath) {
   this._defaultSuffix = '.js'
 
   /**
-   * Map of filenames to the parsed proto descriptor.
+   * Map of absolute filenames to the parsed proto descriptor.
    * @private {Object.<pbnj.ProtoDescriptor>}
    */
   this._protos = {}
@@ -73,9 +78,7 @@ module.exports = Project
  */
 Project.prototype._outputFn = Project.defaultOutputFn = function (descriptor, outFile, compiledContents) {
   return helper.mkdir(outFile).then(function () {
-    var deferred = kew.defer()
-    fs.writeFile(outFile, compiledContents, deferred.makeNodeResolver())
-    return deferred.promise
+    return kew.nfcall(fs.writeFile, outFile, compiledContents)
   })
 }
 
@@ -87,6 +90,7 @@ Project.prototype._outputFn = Project.defaultOutputFn = function (descriptor, ou
 Project.prototype.inspect = function () {
   return util.inspect({
     basePath: this._basePath,
+    protocPaths: this._protocPaths,
     outDir: this._outDir,
     templateDir: this._templateDir,
     jobs: this._compileJobs,
@@ -111,7 +115,7 @@ Project.prototype.setSkipImports = function (skipImports) {
  * @return {Project}
  */
 Project.prototype.setTemplateDir = function (templateFolder) {
-  this._templateDir = templateFolder
+  this._templateDir = path.resolve(this._basePath, templateFolder)
   return this
 }
 
@@ -129,12 +133,24 @@ Project.prototype.setOutputFn = function (outputFn) {
 
 
 /**
- * Sets the output directory to use.  It will be resolved relative to baseDir.
+ * Sets the output directory to use.  It will be resolved relative to the first directory
  * @param {string} outDir
  * @return {Project}
  */
 Project.prototype.setOutDir = function (outDir) {
-  this._outDir = this._resolve(outDir)
+  this._outDir = path.resolve(this._basePath, outDir)
+  return this
+}
+
+
+/**
+ * Sets the protoc_path for resolving proto files.
+ * @param {Array.<string>} protocPaths
+ * @return {Project}
+ */
+Project.prototype.setProtocPaths = function (protocPaths) {
+  if (!Array.isArray(protocPaths)) throw new Error('required array')
+  this._protocPaths = protocPaths
   return this
 }
 
@@ -169,7 +185,7 @@ Project.prototype.addProto = function (fileName) {
 
 /**
  * Processes a protocol buffer schema file, synchronously.
- * @param {string} fileName Filename relative to the project's base path.
+ * @param {string} fileName Filename relative to protoc_paths
  * @return {ProtoDescriptor}
  */
 Project.prototype._getProto = function (fileName) {
@@ -183,7 +199,7 @@ Project.prototype._getProto = function (fileName) {
     proto = this._protos[filePath] = parser(filePath, fileContents)
     if (this._followImports) {
       proto.getImportNames().forEach(function (importName) {
-        proto.addImport(this._getProto(importName, true))
+        proto.addImport(this._getProto(importName))
       }, this)
     }
   }
@@ -203,10 +219,7 @@ Project.prototype.compile = function () {
     eraseTemporaryFiles: false
   })
 
-  var deferred = kew.defer()
-  soynode.compileTemplates(this._resolve(this._templateDir), deferred.makeNodeResolver())
-
-  return deferred.promise.then(function () {
+  return kew.nfcall(soynode.compileTemplates.bind(soynode, this._templateDir)).then(function () {
     var promises = []
 
     for (var i = 0; i < this._compileJobs.length; i++) {
@@ -263,15 +276,28 @@ Project.prototype.getProtos = function (opt_protoFile) {
  * Returns the full path relative to the base directory.
  * @param {string} fileName
  * @return {string}
+ * @throws An error if it could not be resolved
  */
 Project.prototype._resolve = function (fileName) {
-  return path.resolve(this._basePath, fileName)
+  for (var i = 0; i < this._protocPaths.length; i++) {
+    var protocPath = this._protocPaths[i]
+    var filePath = path.resolve(protocPath, fileName)
+    try {
+      fs.statSync(filePath) // https://github.com/nodejs/io.js/issues/103
+      return filePath
+    } catch (err) {} // Expected
+  }
+
+  // TODO(nick): it would be nice to report the line number
+  // where the import appeared, if this is an import.
+  throw new Error('File "' + fileName + '" could not be resolved on protoc paths: ' +
+                  this._protocPaths.join(','))
 }
 
 
 /**
  * Recursively gathers all imported protocol buffers
- * @param {string} file
+ * @param {string} file The absolute file path
  * @param {Object} visited
  * @return {Array.<ProtoDescriptor>}
  */
@@ -282,8 +308,9 @@ Project.prototype._getImported = function (file, visited) {
   if (this._followImports) {
     var imports = this._protos[file].getImportNames()
     for (var i = 0; i < imports.length; i++) {
-      if (!visited[imports[i]]) {
-        protos = protos.concat(this._getImported(imports[i], visited))
+      var importPath = this._resolve(imports[i])
+      if (!visited[importPath]) {
+        protos = protos.concat(this._getImported(importPath, visited))
       }
     }
   }

--- a/lib/descriptors/ProtoDescriptor.js
+++ b/lib/descriptors/ProtoDescriptor.js
@@ -98,7 +98,7 @@ ProtoDescriptor.prototype.getOptionKeys = function () {
 
 
 ProtoDescriptor.prototype.addImportName = function (fileName) {
-  this._importNames.push(path.resolve(fileName))
+  this._importNames.push(fileName)
   return this
 }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -62,7 +62,6 @@ module.exports = function parser(identifier, string) {
       case 'extend':
         parseExtend(proto)
         break
-
       default:
         throw Error('Unexpected token in "' + identifier + '"; ' + token.content)
     }
@@ -92,7 +91,7 @@ module.exports = function parser(identifier, string) {
     }
 
     var equals = expect(Token.Type.OPERATOR)
-    var value = expect(Token.Type.STRING)
+    var value = expect([Token.Type.STRING, Token.Type.WORD])
     expect(Token.Type.TERMINATOR)
     parent.addOption(key.content, value.content)
     // TODO : Handle duplicate options.
@@ -117,10 +116,10 @@ module.exports = function parser(identifier, string) {
           // Recursive parsing of nested messages.
           parseMessage(message)
           break
-         case 'option':
+        case 'option':
           parseOption(message)
           break
-       case 'enum':
+        case 'enum':
           parseEnum(message)
           break
         case 'required':
@@ -131,6 +130,9 @@ module.exports = function parser(identifier, string) {
           break
         case 'repeated':
           parseRepeatedField(message)
+          break
+        case 'extensions':
+          parseExtensions(proto)
           break
         default:
           throw new ParseError(identifier, token)
@@ -198,6 +200,7 @@ module.exports = function parser(identifier, string) {
       expect(Token.Type.TERMINATOR)
       enumeration.addValue(name, Number(number.content))
     })
+    expectOptional(Token.Type.TERMINATOR)
   }
 
   // Parses extend: extend google.protobuf.MessageOptions {optional string type = 50001;}
@@ -206,6 +209,16 @@ module.exports = function parser(identifier, string) {
     parseBlock(function (token) {
       // TODO : parse and add to descriptor
     })
+  }
+
+  // Parses extensions: extensions 1 to max;
+  function parseExtensions(parent) {
+    expect([Token.Type.WORD, Token.Type.NUMBER])
+    if (expect(Token.Type.WORD).content != 'to') {
+      throw new ParseError(identifier, token, 'expected "to".')
+    }
+    expect([Token.Type.WORD, Token.Type.NUMBER])
+    expect(Token.Type.TERMINATOR)
   }
 
   // Parses field options: [ name1 = value1, name2 = value2, (name3) = value3 ]
@@ -228,7 +241,7 @@ module.exports = function parser(identifier, string) {
       expect(Token.Type.OPERATOR)
       var value = expect([Token.Type.WORD, Token.Type.STRING, Token.Type.NUMBER]).content
       parent.addOption(name, value)
-      if (peek().type == Token.Type.DELIMITER) expect(Token.Type.DELIMITER)
+      expectOptional(Token.Type.DELIMITER)
     }, Token.Type.START_OPTION, Token.Type.END_OPTION)
   }
 
@@ -258,6 +271,10 @@ module.exports = function parser(identifier, string) {
       if (token.type == types[i]) return true
     }
     return false
+  }
+
+  function expectOptional(type) {
+    if (peek() && peek().type == type) expect(type)
   }
 
   // Gets the next token and throws an error if it doesn't match one of the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbnj",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "keywords": ["protocol", "buffer", "proto", "protobuf", "parser", "codegen"],
   "description": "JavaScript protocol buffer schema parser and template based code generator",
   "homepage": "https://github.com/dpup/pbnj",

--- a/tests/parsing_test.js
+++ b/tests/parsing_test.js
@@ -21,7 +21,7 @@ exports.testKitchenSinkParsing = function (test) {
 
   // Test imports.
   test.equal(proto.getImportNames().length, 2)
-  test.equal(proto.getImportNames()[0], path.join(process.cwd(), 'tests/protos/options.proto'))
+  test.equal(proto.getImportNames()[0], 'protos/options.proto')
 
   // Test proto level options.
   test.equal(proto.getOptionKeys().length, 2)

--- a/tests/project_test.js
+++ b/tests/project_test.js
@@ -8,10 +8,11 @@ var fs = require('fs')
 var path = require('path')
 var Project = require('../lib/Project')
 
+var baseDir = __dirname
 
 exports.testGetProtos = function (test) {
-  var project = new Project(__dirname)
-    .addProto('protos/vehicle.proto', true)
+  var project = new Project(baseDir)
+    .addProto('protos/vehicle.proto')
 
   var allProtos = project.getProtos().map(getProtoName)
   test.deepEqual(['vehicle.proto', 'common.proto', 'person.proto'], allProtos)
@@ -38,7 +39,7 @@ exports.testGetProtos = function (test) {
 
 exports.testBasicCompilation = function (test) {
   var compilations = []
-  new Project(__dirname)
+  new Project(baseDir)
     .addJob('protos/vehicle.proto', 'protoTemplate.justNames', '.xx.js')
     .setOutDir('generated-stuff')
     .setOutputFn(function (descriptor, fileName, contents) {
@@ -75,7 +76,7 @@ exports.testDefaultOutputFnWritesFile = function (test) {
   // Make sure the expected file doesn't exist yet.
   if (fs.existsSync(expectedFile)) fs.unlinkSync(expectedFile)
 
-  new Project(__dirname)
+  new Project(baseDir)
     .addJob('protos/common.proto', 'protoTemplate.justNames')
     .setOutDir('generated-stuff2')
     .compile()
@@ -87,6 +88,23 @@ exports.testDefaultOutputFnWritesFile = function (test) {
     .fail(function (err) {
       console.log(err.stack)
     })
+}
+
+exports.testKitchenSinkProto = function (test) {
+  var project = new Project(baseDir)
+      .addProto('protos/kitchen-sink.proto')
+
+  var allProtos = project.getProtos().map(getProtoName)
+  test.deepEqual(['kitchen-sink.proto', 'options.proto', 'descriptor.proto'], allProtos)
+
+  project.setOutDir('generated-stuff3')
+      .compile()
+      .then(function () {
+        test.done()
+      }, function (err) {
+        test.ifError(err)
+        test.done()
+      })
 }
 
 

--- a/tests/protoc_test.sh
+++ b/tests/protoc_test.sh
@@ -2,7 +2,7 @@
 
 cd `dirname $0`/..
 mkdir tmp_protoc_test
-protoc tests/protos/*.proto --proto_path=.:/usr/local/include --cpp_out=tmp_protoc_test
+protoc tests/protos/*.proto --proto_path=./tests:/usr/local/include --cpp_out=tmp_protoc_test
 RESULT=$?
 rm -fR tmp_protoc_test
 exit $RESULT

--- a/tests/protos/kitchen-sink.proto
+++ b/tests/protos/kitchen-sink.proto
@@ -6,7 +6,7 @@
 
 package some_package;
 
-import "tests/protos/options.proto";
+import "protos/options.proto";
 import "google/protobuf/descriptor.proto";
 
 option (file_level_option) = "string value";

--- a/tests/protos/person.proto
+++ b/tests/protos/person.proto
@@ -2,7 +2,7 @@
  * Proto definition for a Person
  */
 
-import "tests/protos/common.proto";
+import "protos/common.proto";
 
 package examples;
 

--- a/tests/protos/vehicle.proto
+++ b/tests/protos/vehicle.proto
@@ -1,7 +1,7 @@
 // Proto definition for a Car
 
-import "tests/protos/common.proto";
-import "tests/protos/person.proto";
+import "protos/common.proto";
+import "protos/person.proto";
 
 package examples;
 


### PR DESCRIPTION
Hello @jyhsu, @dpup, 

Please review the following commits I made in branch 'nick-imports'.

9a3064c33806f5840046b7301187f7c1a22f3c06 (2015-07-02 15:30:11 -0400)
clean up how proto imports are handled, and include descriptor.proto by default for portability

R=@jyhsu
R=@dpup

Test plan: 'not tested'