### PR TITLE
respect java_outer_classname for filenames suffixed with .java

### DIFF
--- a/lib/Project.js
+++ b/lib/Project.js
@@ -227,7 +227,11 @@ Project.prototype.compile = function () {
       var protoDescriptors = this.getProtos(job.proto)
       for (var j = 0; j < protoDescriptors.length; j++) {
         var descriptor = protoDescriptors[j]
-        var fileName = path.join(this._outDir, descriptor.getName() + (job.suffix || this._defaultSuffix))
+        var baseFileName = descriptor.getName()
+        if (job.suffix == '.java' && descriptor.getOption('java_outer_classname')) {
+          baseFileName = descriptor.getOption('java_outer_classname')
+        }
+        var fileName = path.join(this._outDir, baseFileName + (job.suffix || this._defaultSuffix))
         var contents = soynode.render(job.template, descriptor.toTemplateObject())
         promises.push(this._outputFn(descriptor, fileName, contents))
       }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch 'jean-version'.

bbdb9073b0053cd6521c340f26622d0e7f502078 (2015-07-06 14:34:45 -0700)
respect java_outer_classname for filenames suffixed with .java

R=@nicks